### PR TITLE
Set data base path method

### DIFF
--- a/parsers/features/base_parser.py
+++ b/parsers/features/base_parser.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from ..infra.client import Client, configs
+
+
+class BaseParser:
+    def __init__(self, config_box: configs.ConfigBox) -> None:
+        self._config_box = config_box
+        self._client = Client(self._config_box)
+
+    def set_db_path(self, new_fp: str) -> None:
+        if self._client.bootstrapped:
+            return
+        new_fp = Path(new_fp)
+        if not new_fp.suffix:
+            new_fp = new_fp.joinpath(self._config_box.cache.name)
+        self._config_box.cache.name = str(new_fp)

--- a/parsers/features/schedule/parser.py
+++ b/parsers/features/schedule/parser.py
@@ -1,4 +1,5 @@
-from ...infra.client import Client, configs
+from ...infra.client import configs
+from ..base_parser import BaseParser
 from .scrapers import (
     DailyScheduleScraper,
     GroupExistenceScraper,
@@ -6,9 +7,9 @@ from .scrapers import (
 )
 
 
-class ScheduleParser:
+class ScheduleParser(BaseParser):
     def __init__(self, config_box: configs.ConfigBox) -> None:
-        self._client = Client(config_box)
+        super().__init__(config_box)
         self.group_exist = GroupExistenceScraper(self._client)
         self.get_week_schedule = WeekScheduleScraper(self._client)
         self.get_daily_schedule = DailyScheduleScraper(self._client)

--- a/parsers/features/song_lyrics/parser.py
+++ b/parsers/features/song_lyrics/parser.py
@@ -1,9 +1,10 @@
-from ...infra.client import Client, configs
+from ...infra.client import configs
+from ..base_parser import BaseParser
 from .scrapers import SearchSongsScraper, SongLyricsScraper
 
 
-class SongLyricsParser:
+class SongLyricsParser(BaseParser):
     def __init__(self, config_box: configs.ConfigBox) -> None:
-        self._client = Client(config_box)
+        super().__init__(config_box)
         self.search_songs = SearchSongsScraper(self._client)
         self.get_song_lyrics = SongLyricsScraper(self._client)

--- a/parsers/infra/client/client.py
+++ b/parsers/infra/client/client.py
@@ -18,7 +18,7 @@ from .type_defs import ProxyLike, SessionLike
 class Client:
     def __init__(self, configs: ConfigBox) -> None:
         self._time_last_cache_prune: float = float("-inf")
-        self._bootstrapped = False
+        self.bootstrapped = False
 
         self._configs = configs
         self._session_manager = SessionManager(configs)
@@ -30,7 +30,7 @@ class Client:
         self._adapters = AdaptersController(self._session_manager, self._configs)
 
     def _ensure_bootstrapped(self) -> None:
-        if self._bootstrapped:
+        if self.bootstrapped:
             return
         self._cookies.update(self._configs.cookie.initial)
         self._cookies.update(self._configs.cookie.file)
@@ -39,7 +39,7 @@ class Client:
         headers = dict(self._configs.net.headers)
         headers.setdefault("User-Agent", self._configs.net.user_agent or UserAgent().random)
         self._headers.update(headers)
-        self._bootstrapped = True
+        self.bootstrapped = True
 
     @property
     def session(self) -> SessionLike:
@@ -111,7 +111,7 @@ class Client:
         return resp
 
     def close(self) -> None:
-        if self._bootstrapped:
+        if self.bootstrapped:
             self.cache.prune()
             self.session.close()
 


### PR DESCRIPTION
# Добавление удобства по работе с файлом базы данных

## Что именно сделал?
Я добавил класс `BaseParser` и определил в нем метод `set_db_path`

## Зачем это и что было не так до этого? 
Ранее, если вы импортировали экземпляр парсера с пакета `parsers`, например `schedule_parser`, то файл базы создавался автоматически, при первом взаимодействии с экземпляром, с дефолтым названием, например: `schedule_parser_cache.sqlite`, рядом с `*.py` файлом, в котором вы и импортировали пакет. Это название нельзя было поменять, как и поместить файл базы по конкретному пути.

## Как было решено и как этим пользоваться?
Теперь у любого экземпляра пакета есть метод `Parse.set_db_path(new_fp: str)` через который можно удобно и гибко задать место, где будет храниться файл базы.
Например:
```python
# main.py
from parsers import schedule_parser

schedule_parser.set_db_path("A/B/C")
...
```
Древо:
```text
- main.py
| - A
  | - B
    | - C
      | - schedule_parser_cache.sqlite
```
---

```python
# main.py
from parsers import schedule_parser

schedule_parser.set_db_path("A/B/my_db.sqlite")
...
```
Древо:
```text
- main.py
| - A
  | - B
    | - my_db.sqlite
```

## Важное замечание ❗❗❗
Этот метод стоит вызывать перед работой с экземпляром, т.е. до вызова всех остальных его методов. Это объясняется ленивой загрузкой кэша. При попытке вызова метода после bootstrap-а экземпляра, вызов будет проигнорирован. 

## Резюмируя:
Хочу сказать, что на данный момент я реализовал всё то, что хотел видеть в этой части проекта, пакете `parsers`. Но конечно же приветствуются замечания @convulsiva )
Но остаётся вопрос, как будет асинхронный бот дружить с синхронным пакетом?)
Может пока стоит оставить всё в этой части синхронным, по крайней мере до тех пор, пока не перепишем часть бота.

<img width="240" height="300" alt="image" src="https://github.com/user-attachments/assets/fb8106a0-e00c-4a7d-bc4d-f2c31121614e" />
